### PR TITLE
hook unit testing to CI

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         julia-version: [1.0, 1.5]
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, macOS-latest]
     steps:
       - uses: actions/checkout@v1.0.0
       - uses: azure/login@v1.1

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -1,0 +1,38 @@
+name: Tests
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        julia-version: [1.0, 1.5]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+    steps:
+      - uses: actions/checkout@v1.0.0
+      - uses: azure/login@v1.1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: ${{ matrix.julia-version }}
+      - name: Generate UUID
+        id: uuid
+        run: julia -e 'using Random; write(stdout,"::set-output name=uuid::"*lowercase(randstring(21)))'
+        shell: bash
+      - name: Run Az CLI script
+        run: |
+          az group create -l southcentralus -n "azstorage-${{ matrix.os }}-${{ matrix.julia-version }}-${{ github.run_id }}"
+          az storage account create -n "s${{ steps.uuid.outputs.uuid }}" -g "azstorage-${{ matrix.os }}-${{ matrix.julia-version }}-${{ github.run_id }}" -l southcentralus
+      - uses: julia-actions/julia-buildpkg@latest #change lastest to master
+      - uses: julia-actions/julia-runtest@latest #change lastest to master
+        env:
+          AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
+          STORAGE_ACCOUNT: "s${{ steps.uuid.outputs.uuid }}"
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v1
+        with:
+          file: lcov.info
+      - name: Run Az CLI script
+        run: |
+          az group delete -n "azstorage-${{ matrix.os }}-${{ matrix.julia-version }}-${{ github.run_id }}" --yes
+        if: ${{ always() }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,22 @@
 # AzStorage.jl
 
-[![](https://img.shields.io/badge/docs-stable-blue.svg)](https://ChevronETC.github.io/AzStorage.jl/stable)
-[![](https://img.shields.io/badge/docs-dev-blue.svg)](https://ChevronETC.github.io/AzStorage.jl/dev)
+| **Documentation** | **Action Statuses** |
+|:---:|:---:|
+| [![][docs-dev-img]][docs-dev-url] [![][docs-stable-img]][docs-stable-url] | [![][doc-build-status-img]][doc-build-status-url] [![][build-status-img]][build-status-url] [![][code-coverage-img]][code-coverage-results] |
 
 Interface to Azure blob storage.
+
+[docs-dev-img]: https://img.shields.io/badge/docs-dev-blue.svg
+[docs-dev-url]: https://chevronetc.github.io/AzStorage.jl/dev/
+
+[docs-stable-img]: https://img.shields.io/badge/docs-stable-blue.svg
+[docs-stable-url]: https://ChevronETC.github.io/AzStorage.jl/stable
+
+[doc-build-status-img]: https://github.com/ChevronETC/AzStorage.jl/workflows/Documentation/badge.svg
+[doc-build-status-url]: https://github.com/ChevronETC/AzStorage.jl/actions?query=workflow%3ADocumentation
+
+[build-status-img]: https://github.com/ChevronETC/AzStorage.jl/workflows/Tests/badge.svg
+[build-status-url]: https://github.com/ChevronETC/AzStorage.jl/actions?query=workflow%3A"Tests"
+
+[code-coverage-img]: https://codecov.io/gh/ChevronETC/AzStorage.jl/branch/master/graph/badge.svg
+[code-coverage-results]: https://codecov.io/gh/ChevronETC/AzStorage.jl

--- a/src/AzStorage.jl
+++ b/src/AzStorage.jl
@@ -174,7 +174,9 @@ function nblocks(nthreads::Integer, nbytes::Integer)
     nblocks
 end
 
-addprefix(c::AzContainer, o) = c.prefix == "" ? o : normpath("$(c.prefix)/$o")
+_normpath(s) = Sys.iswindows() ? replace(normpath(s), "\\"=>"/") : normpath(s)
+
+addprefix(c::AzContainer, o) = c.prefix == "" ? o : _normpath("$(c.prefix)/$o")
 
 function writebytes(c::AzContainer, o::AbstractString, data::DenseArray{UInt8}; contenttype="application/octet-stream")
     function writebytes_blob(c, o, data, contenttype)
@@ -393,7 +395,7 @@ function Base.readdir(c::AzContainer; filterlist=true)
         blobs = xroot["Blobs"][1]["Blob"]
         _names = [content(blob["Name"][1]) for blob in blobs]
         if filterlist && c.prefix != ""
-            _names = replace.(filter(_name->startswith(_name, c.prefix), _names), normpath(c.prefix*"/")=>"")
+            _names = replace.(filter(_name->startswith(_name, c.prefix), _names), _normpath(c.prefix*"/")=>"")
         end
         names = [names; _names]
         marker = content(xroot["NextMarker"][1])
@@ -412,7 +414,7 @@ function Base.dirname(c::AzContainer)
     if c.prefix == ""
         nm = c.containername
     else
-        nm = normpath(c.containername * "/" * c.prefix)
+        nm = _normpath(c.containername * "/" * c.prefix)
     end
     nm
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,10 @@
 using AbstractStorage, AzSessions, AzStorage, Dates, JSON, Random, Test
 
-session = AzSession(read(joinpath(homedir(),"session.json"), String))
+credentials = JSON.parse(ENV["AZURE_CREDENTIALS"])
+AzSessions.write_manifest(;client_id=credentials["clientId"], client_secret=credentials["clientSecret"], tenant=credentials["tenantId"])
+
+session = AzSession(;protocal=AzClientCredentials, client_id=credentials["clientId"], client_secret=credentials["clientSecret"], resource="https://storage.azure.com/")
+
 storageaccount = ENV["STORAGE_ACCOUNT"]
 @info "storageaccount=$storageaccount"
 
@@ -220,7 +224,7 @@ end
 
 @testset "Object, bytes" begin
     sleep(1)
-    r = lowercase(randstring(MersenneTwister(millisecond(now())+13)))
+    r = lowercase(randstring(MersenneTwister(millisecond(now())+14)))
     c = AzContainer("foo-$r-k", storageaccount=storageaccount, session=session, nthreads=2, nretry=10)
     io = open(c, "bar")
     x = rand(10)
@@ -232,7 +236,7 @@ end
 
 @testset "Object, bytes" begin
     sleep(1)
-    r = lowercase(randstring(MersenneTwister(millisecond(now())+13)))
+    r = lowercase(randstring(MersenneTwister(millisecond(now())+15)))
     c = AzContainer("foo-$r-k", storageaccount=storageaccount, session=session, nthreads=2, nretry=10)
     io = open(c, "bar")
     write(io, "hello")
@@ -243,7 +247,7 @@ end
 
 @testset "Object, isfile" begin
     sleep(1)
-    r = lowercase(randstring(MersenneTwister(millisecond(now())+13)))
+    r = lowercase(randstring(MersenneTwister(millisecond(now())+16)))
     c = AzContainer("foo-$r-k", storageaccount=storageaccount, session=session, nthreads=2, nretry=10)
     io = open(c, "bar")
     write(io, "hello")
@@ -253,7 +257,7 @@ end
 
 @testset "Object, rm" begin
     sleep(1)
-    r = lowercase(randstring(MersenneTwister(millisecond(now())+13)))
+    r = lowercase(randstring(MersenneTwister(millisecond(now())+17)))
     c = AzContainer("foo-$r-k", storageaccount=storageaccount, session=session, nthreads=2, nretry=10)
     io = open(c, "bar")
     write(io, "hello")
@@ -265,7 +269,7 @@ end
 
 @testset "Object, joinpath" begin
     sleep(1)
-    r = lowercase(randstring(MersenneTwister(millisecond(now())+13)))
+    r = lowercase(randstring(MersenneTwister(millisecond(now())+18)))
     c = AzContainer("foo-$r-k", storageaccount=storageaccount, session=session, nthreads=2, nretry=10)
     io = joinpath(c, "bar", "baz")
     write(io, "hello")
@@ -277,7 +281,7 @@ end
 # Anusha found the failing example.
 @testset "Anusha's example" begin
     sleep(1)
-    r = lowercase(randstring(MersenneTwister(millisecond(now())+14)))
+    r = lowercase(randstring(MersenneTwister(millisecond(now())+19)))
     c = AzContainer("foo-$r-l", storageaccount=storageaccount, session=session, nthreads=2, nretry=10)
     mkpath(c)
     x = rand(2801,13821)


### PR DESCRIPTION
For now, this only has a single item in the test matrix.  In addition, this will probably not work if there are several commits exercising the unit tests simultaneously.  I think we should merge this, and then think about how to solve the subsequent problems.

The simplest solution would probably be to simply keep permanent versions of the resource group and storage accounts rather than create them on the fly.  