### PR TITLE
add readdlm/writedlm methods to AzStorage

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,17 +7,18 @@ AbstractStorage = "14dbef02-f468-5f15-853e-5ec8dee7b899"
 AzSessions = "f239b30d-ae6b-58be-a2d5-7e9f30e280a9"
 AzStorage_jll = "00c928b4-b5f3-54d8-b38d-afd4635c4ad2"
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 LightXML = "9c8b4983-aa76-5018-a973-4c85ecc9e179"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [compat]
-julia = "1"
 AbstractStorage = "1"
 AzSessions = "1"
 HTTP = "0.8"
 LightXML = "0.9"
+julia = "1"
 
 [extras]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -24,7 +24,9 @@ joinpath
 open
 read
 read!
+readdlm
 rm(::AzContainer, ::AbstractString)
 rm(::AzStorage.AzObject)
 write
+writedlm
 ```

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -13,7 +13,9 @@ dirname
 isdir
 mkpath
 readdir
+readdlm
 rm(::AzContainer)
+writedlm
 ```
 
 ## Blob methods

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -13,9 +13,7 @@ dirname
 isdir
 mkpath
 readdir
-readdlm
 rm(::AzContainer)
-writedlm
 ```
 
 ## Blob methods

--- a/src/AzStorage.jl
+++ b/src/AzStorage.jl
@@ -291,8 +291,8 @@ Write the array `data` to a delimited blob with the name `blobname` in container
 """
 function DelimitedFiles.writedlm(c::AzContainer, o::AbstractString, data::AbstractArray, args...; opts...)
     io = IOBuffer(;write=true)
-    writedlm(io,data, args...; opts...)
-    write(c,o,String(take!(io)))
+    writedlm(io, data, args...; opts...)
+    write(c, o, String(take!(io)))
 end
 
 """
@@ -317,7 +317,7 @@ end
 Read the data in a delimited blob with the name `blobname` in container `container::AzContainer`
 """
 function DelimitedFiles.readdlm(c::AzContainer, o::AbstractString, args...; opts...)
-    io = IOBuffer(;write=true,read=true)
+    io = IOBuffer(;write=true, read=true)
     write(io, read(c, o, String))
     seekstart(io)
     readdlm(io, args...; opts...)
@@ -334,7 +334,7 @@ io = open(AzContainer("mycontainer";storageaccount="mystorageaccount"), "foo.txt
 data = readdlm(io)
 ```
 """
-function DelimitedFiles.readdlm(o::AzStorage.AzObject, args...; opts...)
+function DelimitedFiles.readdlm(o::AzObject, args...; opts...)
     readdlm(o.container, o.name, args...; opts...)
 end
 

--- a/src/AzStorage.jl
+++ b/src/AzStorage.jl
@@ -285,18 +285,18 @@ x = read!(io, zeros(10))
 Base.write(o::AzObject, data) = write(o.container, o.name, data)
 
 """
-    writedlm(container, "blobname", data)
+    writedlm(container, "blobname", data, args...; options...)
 
 Write the array `data` to a delimited blob with the name `blobname` in container `container::AzContainer`
 """
-function DelimitedFiles.writedlm(c::AzContainer, o::AbstractString, data::AbstractArray)
+function DelimitedFiles.writedlm(c::AzContainer, o::AbstractString, data::AbstractArray, args...; opts...)
     io = IOBuffer(;write=true)
-    writedlm(io, data)
+    writedlm(io,data, args...; opts...)
     write(c,o,String(take!(io)))
 end
 
 """
-    writedlm(io:AzObject, data)
+    writedlm(io:AzObject, data, args...; options...)
 
 write the array `data` to `io::AzObject`
 
@@ -307,24 +307,24 @@ writedlm(io, rand(10,10))
 x = readdlm(io)
 ```
 """
-function DelimitedFiles.writedlm(o::AzObject, data::AbstractArray)
-     writedlm(o.container, o.name, data)
+function DelimitedFiles.writedlm(o::AzObject, data::AbstractArray, args...; opts...)
+     writedlm(o.container, o.name, data, args...; opts...)
 end
 
 """
-    readdlm(container, "blobname")
+    readdlm(container, "blobname", args...; options...)
 
 Read the data in a delimited blob with the name `blobname` in container `container::AzContainer`
 """
-function DelimitedFiles.readdlm(c::AzContainer, o::AbstractString)
-    io = IOBuffer(;write=true, read=true)
+function DelimitedFiles.readdlm(c::AzContainer, o::AbstractString, args...; opts...)
+    io = IOBuffer(;write=true,read=true)
     write(io, read(c, o, String))
     seekstart(io)
-    readdlm(io)
+    readdlm(io, args...; opts...)
 end
 
 """
-    readdlm(io:AzObject)
+    readdlm(io:AzObject, args...; options...)
 
 return the parsed delimited blob from the io object `io::AzObject`
 
@@ -334,8 +334,13 @@ io = open(AzContainer("mycontainer";storageaccount="mystorageaccount"), "foo.txt
 data = readdlm(io)
 ```
 """
-function DelimitedFiles.readdlm(o::AzObject)
-    readdlm(o.container, o.name)
+function DelimitedFiles.readdlm(o::AzStorage.AzObject, args...; opts...)
+    readdlm(o.container, o.name, args...; opts...)
+end
+
+#this is to resolve an function call ambiguity
+function DelimitedFiles.readdlm(o::AzObject, delim::AbstractChar, args...; opts...)
+    readdlm(o.container, o.name, delim, args...; opts...)
 end
 
 nthreads_effective(nthreads::Integer, nbytes::Integer) = clamp(div(nbytes, _MINBYTES_PER_BLOCK), 1, nthreads)

--- a/src/AzStorage.jl
+++ b/src/AzStorage.jl
@@ -291,7 +291,7 @@ Write the array `data` to a delimited blob with the name `blobname` in container
 """
 function DelimitedFiles.writedlm(c::AzContainer, o::AbstractString, data::AbstractArray)
     io = IOBuffer(;write=true)
-    DelimitedFiles.writedlm(io,data)
+    writedlm(io, data)
     write(c,o,String(take!(io)))
 end
 
@@ -317,7 +317,7 @@ end
 Read the data in a delimited blob with the name `blobname` in container `container::AzContainer`
 """
 function DelimitedFiles.readdlm(c::AzContainer, o::AbstractString)
-    io = IOBuffer(;write=true,read=true)
+    io = IOBuffer(;write=true, read=true)
     write(io, read(c, o, String))
     seekstart(io)
     readdlm(io)
@@ -334,7 +334,7 @@ io = open(AzContainer("mycontainer";storageaccount="mystorageaccount"), "foo.txt
 data = readdlm(io)
 ```
 """
-function DelimitedFiles.readdlm(o::AzStorage.AzObject)
+function DelimitedFiles.readdlm(o::AzObject)
     readdlm(o.container, o.name)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -306,7 +306,9 @@ end
 @testset "writedlm and readdlm" begin
     sleep(1)
     a = rand(1000,1000)
+    r = lowercase(randstring(MersenneTwister(millisecond(now())+19)))
     c = AzContainer("foo-$r-m", storageaccount=storageaccount, session=session, nthreads=2, nretry=10)
+    mkpath(c)
     io = open(c, "bar")
     writedlm(io,a)
     _a = readdlm(io)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -302,3 +302,14 @@ end
     @test x ≈ _x
     rm(c)
 end
+
+@testset "writedlm and readdlm" begin
+    sleep(1)
+    a = rand(1000,1000)
+    c = AzContainer("foo-$r-m", storageaccount=storageaccount, session=session, nthreads=2, nretry=10)
+    io = open(c, "bar")
+    writedlm(io,a)
+    _a = readdlm(io)
+    @test _a ≈ a
+    rm(c)
+end 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -306,9 +306,8 @@ end
 @testset "writedlm and readdlm" begin
     sleep(1)
     a = rand(1000,1000)
-    r = lowercase(randstring(MersenneTwister(millisecond(now())+19)))
+    r = lowercase(randstring(MersenneTwister(millisecond(now())+20)))
     c = AzContainer("foo-$r-m", storageaccount=storageaccount, session=session, nthreads=2, nretry=10)
-    mkpath(c)
     io = open(c, "bar")
     writedlm(io,a)
     _a = readdlm(io)


### PR DESCRIPTION
Add methods to be able to deal with delimited files in blobstore.
The DelimitedFiles functions readdlm and writedlm  are extended. 

Note - I did not create functions that can accept all the different options that readdlm/writedlm in DelimitedFiles have.
We could add if it is needed. 