### PR TITLE
Improve Makefile

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -1,8 +1,8 @@
-libAzStorage.$(dlext): AzStorage.o
+libAzStorage.so: AzStorage.o
 	$(CC) -shared -fopenmp -o $@ $^ `curl-config --libs`
 
 AzStorage.o: AzStorage.c
 	$(CC) `curl-config --cflags` -O3 -fopenmp -fPIC -c -o $@ $^
 
 clean:
-	rm -rf *.$(dlext) *.o
+	rm -rf *.so *.o

--- a/src/makefile
+++ b/src/makefile
@@ -1,6 +1,8 @@
-all:
-	gcc `curl-config --cflags` -O3 -fopenmp -fPIC -c AzStorage.c
-	gcc -shared -fopenmp -o libAzStorage.so AzStorage.o `curl-config --libs` ${LDFLAGS}
+libAzStorage.$(dlext): AzStorage.o
+	$(CC) -shared -fopenmp -o $@ $^ `curl-config --libs`
+
+AzStorage.o: AzStorage.c
+	$(CC) `curl-config --cflags` -O3 -fopenmp -fPIC -c -o $@ $^
 
 clean:
-	rm -rf *.so *.o
+	rm -rf *.$(dlext) *.o


### PR DESCRIPTION
If this is supposed to be used only in Yggdrasil, I think this would work slightly better, in particular it doesn't force using GCC on BSD systems.