### PR TITLE
yggdrasil specific make target

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -1,8 +1,14 @@
-libAzStorage.so: AzStorage.o
+local:
+	$(CC) `curl-config --cflags` -O3 -fopenmp -fPIC -c -o AzStorage.o AzStorage.c
+	$(CC) -shared -fopenmp -o libAzStorage.so AzStorage.o `curl-config --libs`
+
+yggdrasil: libAzStorage.${dlext}
+
+libAzStorage.${dlext}: AzStorage.o
 	$(CC) -shared -fopenmp -o $@ $^ `curl-config --libs`
 
-AzStorage.o: AzStorage.c
+AzStorage.$(dlext): AzStorage.c
 	$(CC) `curl-config --cflags` -O3 -fopenmp -fPIC -c -o $@ $^
 
 clean:
-	rm -rf *.so *.o
+	rm -rf *.$(dlext) *.o


### PR DESCRIPTION
@giordano I guess this might be the best of both worlds.  Still a bit kludgy, and I should still use cmake, but I think this will work for now.  I can make another PR against the binary builder script so that it uses the `yggdrasil` target.