### PR TITLE
improve timeout handing, using connect and read timeouts

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AzStorage"
 uuid = "c6697862-1611-5eae-9ef8-48803c85c8d6"
-version = "2.2.1"
+version = "2.3.0"
 
 [deps]
 AbstractStorage = "14dbef02-f468-5f15-853e-5ec8dee7b899"
@@ -17,7 +17,7 @@ Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 [compat]
 AbstractStorage = "^1.1"
 AzSessions = "2"
-AzStorage_jll = "0.5"
+AzStorage_jll = "0.7"
 HTTP = "1"
 LightXML = "0.9"
 julia = "^1.6"

--- a/src/AzStorage.h
+++ b/src/AzStorage.h
@@ -12,7 +12,7 @@
 #define BUFFER_SIZE 16000 // this needs to be large to accomodate large OAuth2 tokens
 #define API_HEADER_BUFFER_SIZE 512
 #define MAXIMUM_BACKOFF 256.0
-#define CURLE_TIMEOUT 600L /* 5 hours */
+#define CURLE_TIMEOUT 18000L /* 5 hours */
 
 #define MAX(x, y) (((x) > (y)) ? (x) : (y))
 #define MIN(x, y) (((x) < (y)) ? (x) : (y))
@@ -80,7 +80,9 @@ curl_writebytes_block_retry_threaded(
     int    nthreads,
     int    nblocks,
     int    nretry,
-    int    verbose);
+    int    verbose,
+    long   connect_timeout,
+    long   read_timeout);
 
 struct ResponseCodes
 curl_readbytes_retry_threaded(
@@ -93,7 +95,9 @@ curl_readbytes_retry_threaded(
     size_t datasize,
     int    nthreads,
     int    nretry,
-    int    verbose);
+    int    verbose,
+    long   connect_timeout,
+    long   read_timeout);
 
 struct ResponseCodes
 curl_refresh_tokens_retry(
@@ -106,7 +110,9 @@ curl_refresh_tokens_retry(
     char          *client_secret,
     char          *tenant,
     int            nretry,
-    int            verbose);
+    int            verbose,
+    long           connect_timeout,
+    long           read_timeout);
 
 int
 isrestretrycode(


### PR DESCRIPTION
 We set the default connection timeout to 30 seconds, and the default read timeout to 10 seconds.  The read timeout is a bit tricky in that when using HTTP.jl, it applies to the read of the first byte, but when calls go through LibCurl, it refers to the timeout to read or write the next byte.  Therefore the timeout logic when going through LibCurl seems like it might be a bit more robust than for HTTP.jl.  Because of this, we also change things to use LibCurl even when only writing a blob with a single block.

Please note that this PR will not pass unit tests in CI until AzStorage_jll gets its next release.  However, the tests do pass locally on a Linux machine.