### PR TITLE
when needed, refresh tokens in the retry-loop

### DIFF
--- a/src/AzStorage.c
+++ b/src/AzStorage.c
@@ -476,9 +476,12 @@ curl_refresh_tokens(
 {
     unsigned long current_time = (unsigned long) time(NULL);
     struct ResponseCodes responsecodes;
+
+    responsecodes.http = 200;
+    responsecodes.curl = (long)CURLE_OK;
+    responsecodes.retry_after = 0;
+
     if (current_time < (*expiry - 600)) { /* 10 minute grace period */
-        responsecodes.http = 200;
-        responsecodes.curl = (long)CURLE_OK;
         return responsecodes;
     }
 
@@ -487,10 +490,7 @@ curl_refresh_tokens(
     } else if (refresh_token != NULL) {
         responsecodes = curl_refresh_tokens_from_refresh_token(bearer_token, refresh_token, expiry, scope, resource, clientid, tenant, verbose, connect_timeout, read_timeout);
     } else {
-        printf("Unable to refresh tokens without either a refresh token or a client secret");
-        responsecodes.curl = 1000;
-        responsecodes.http = 1000;
-        responsecodes.retry_after = 0;
+        printf("Warning: unable to refresh token.");
     }
 
     return responsecodes;
@@ -550,17 +550,39 @@ write_callback_readdata(
 
 struct ResponseCodes
 curl_writebytes_block(
-        char   *token,
-        char   *storageaccount,
-        char   *containername,
-        char   *blobname,
-        char   *blockid,
-        char   *data,
-        size_t  datasize,
-        int     verbose,
-        long    connect_timeout,
-        long    read_timeout)
+        char          *token,
+        char          *refresh_token,
+        unsigned long *expiry,
+        char          *scope,
+        char          *resource,
+        char          *tenant,
+        char          *clientid,
+        char          *client_secret,
+        char          *storageaccount,
+        char          *containername,
+        char          *blobname,
+        char          *blockid,
+        char          *data,
+        size_t         datasize,
+        int            nretry,
+        int            verbose,
+        long           connect_timeout,
+        long           read_timeout)
 {
+    curl_refresh_tokens_retry(
+        token,
+        refresh_token,
+        expiry,
+        scope,
+        resource,
+        clientid,
+        client_secret,
+        tenant,
+        nretry,
+        verbose,
+        connect_timeout,
+        read_timeout);
+
     char authorization[BUFFER_SIZE];
     curl_authorization(token, authorization);
     char contentlength[BUFFER_SIZE];
@@ -633,22 +655,29 @@ curl_writebytes_block(
 
 struct ResponseCodes
 curl_writebytes_block_retry(
-        char   *token,
-        char   *storageaccount,
-        char   *containername,
-        char   *blobname,
-        char   *blockid,
-        char   *data,
-        size_t  datasize,
-        int     nretry,
-        int     verbose,
-        long    connect_timeout,
-        long    read_timeout)
+        char          *token,
+        char          *refresh_token,
+        unsigned long *expiry,
+        char          *scope,
+        char          *resource,
+        char          *tenant,
+        char          *clientid,
+        char          *client_secret,
+        char          *storageaccount,
+        char          *containername,
+        char          *blobname,
+        char          *blockid,
+        char          *data,
+        size_t         datasize,
+        int            nretry,
+        int            verbose,
+        long           connect_timeout,
+        long           read_timeout)
 {
     int iretry;
     struct ResponseCodes responsecodes;
     for (iretry = 0; iretry < nretry; iretry++) {
-        responsecodes = curl_writebytes_block(token, storageaccount, containername, blobname, blockid, data, datasize, verbose, connect_timeout, read_timeout);
+        responsecodes = curl_writebytes_block(token, refresh_token, expiry, scope, resource, tenant, clientid, client_secret, storageaccount, containername, blobname, blockid, data, datasize, nretry, verbose, connect_timeout, read_timeout);
         if (isrestretrycode(responsecodes) == 0) {
             break;
         }
@@ -665,19 +694,26 @@ curl_writebytes_block_retry(
 
 struct ResponseCodes
 curl_writebytes_block_retry_threaded(
-        char    *token,
-        char    *storageaccount,
-        char    *containername,
-        char    *blobname,
-        char   **blockids,
-        char    *data,
-        size_t   datasize,
-        int      nthreads,
-        int      nblocks,
-        int      nretry,
-        int      verbose,
-        long     connect_timeout,
-        long     read_timeout)
+        char           *token,
+        char           *refresh_token,
+        unsigned long  *expiry,
+        char           *scope,
+        char           *resource,
+        char           *tenant,
+        char           *clientid,
+        char           *client_secret,
+        char           *storageaccount,
+        char           *containername,
+        char           *blobname,
+        char          **blockids,
+        char           *data,
+        size_t          datasize,
+        int             nthreads,
+        int             nblocks,
+        int             nretry,
+        int             verbose,
+        long            connect_timeout,
+        long            read_timeout)
 {
     size_t block_datasize = datasize/nblocks;
     size_t block_dataremainder = datasize%nblocks;
@@ -705,7 +741,15 @@ curl_writebytes_block_retry_threaded(
             block_firstbyte += block_dataremainder;
         }
 
-        struct ResponseCodes responsecodes = curl_writebytes_block_retry(token, storageaccount, containername, blobname, blockids[iblock], data+block_firstbyte, _block_datasize, nretry, verbose, connect_timeout, read_timeout);
+        char token_local[BUFFER_SIZE];
+        char refresh_token_local[BUFFER_SIZE];
+        unsigned long expiry_local;
+
+        strcpy(token_local, token);
+        strcpy(refresh_token_local, refresh_token);
+        expiry_local = *expiry;
+
+        struct ResponseCodes responsecodes = curl_writebytes_block_retry(token_local, refresh_token_local, &expiry_local, scope, resource, tenant, clientid, client_secret, storageaccount, containername, blobname, blockids[iblock], data+block_firstbyte, _block_datasize, nretry, verbose, connect_timeout, read_timeout);
         thread_responsecode_http[threadid] = MAX(responsecodes.http, thread_responsecode_http[threadid]);
         thread_responsecode_curl[threadid] = MAX(responsecodes.curl, thread_responsecode_curl[threadid]);
     }
@@ -723,17 +767,39 @@ curl_writebytes_block_retry_threaded(
 
 struct ResponseCodes
 curl_readbytes(
-        char   *token,
-        char   *storageaccount,
-        char   *containername,
-        char   *blobname,
-        char   *data,
-        size_t  dataoffset,
-        size_t  datasize,
-        int     verbose,
-        long    connect_timeout,
-        long    read_timeout)
+        char          *token,
+        char          *refresh_token,
+        unsigned long *expiry,
+        char          *scope,
+        char          *resource,
+        char          *tenant,
+        char          *clientid,
+        char          *client_secret,
+        char          *storageaccount,
+        char          *containername,
+        char          *blobname,
+        char          *data,
+        size_t         dataoffset,
+        size_t         datasize,
+        int            nretry,
+        int            verbose,
+        long           connect_timeout,
+        long           read_timeout)
 {
+    curl_refresh_tokens_retry(
+        token,
+        refresh_token,
+        expiry,
+        scope,
+        resource,
+        clientid,
+        client_secret,
+        tenant,
+        nretry,
+        verbose,
+        connect_timeout,
+        read_timeout);
+
     char authorization[BUFFER_SIZE];
     curl_authorization(token, authorization);
 
@@ -808,22 +874,29 @@ curl_readbytes(
 
 struct ResponseCodes
 curl_readbytes_retry(
-        char   *token,
-        char   *storageaccount,
-        char   *containername,
-        char   *blobname,
-        char   *data,
-        size_t  dataoffset,
-        size_t  datasize,
-        int     nretry,
-        int     verbose,
-        long    connect_timeout,
-        long    read_timeout)
+        char          *token,
+        char          *refresh_token,
+        unsigned long *expiry,
+        char          *scope,
+        char          *resource,
+        char          *tenant,
+        char          *clientid,
+        char          *client_secret,
+        char          *storageaccount,
+        char          *containername,
+        char          *blobname,
+        char          *data,
+        size_t         dataoffset,
+        size_t         datasize,
+        int            nretry,
+        int            verbose,
+        long           connect_timeout,
+        long           read_timeout)
 {
     struct ResponseCodes responsecodes;
     int iretry;
     for (iretry = 0; iretry < nretry; iretry++) {
-        responsecodes = curl_readbytes(token, storageaccount, containername, blobname, data, dataoffset, datasize, verbose, connect_timeout, read_timeout);
+        responsecodes = curl_readbytes(token, refresh_token, expiry, scope, resource, tenant, clientid, client_secret, storageaccount, containername, blobname, data, dataoffset, datasize, nretry, verbose, connect_timeout, read_timeout);
         if (isrestretrycode(responsecodes) == 0) {
             break;
         }
@@ -840,18 +913,25 @@ curl_readbytes_retry(
 
 struct ResponseCodes
 curl_readbytes_retry_threaded(
-        char   *token,
-        char   *storageaccount,
-        char   *containername,
-        char   *blobname,
-        char   *data,
-        size_t  dataoffset,
-        size_t  datasize,
-        int     nthreads,
-        int     nretry,
-        int     verbose,
-        long    connect_timeout,
-        long    read_timeout)
+        char          *token,
+        char          *refresh_token,
+        unsigned long *expiry,
+        char          *scope,
+        char          *resource,
+        char          *tenant,
+        char          *clientid,
+        char          *client_secret,
+        char          *storageaccount,
+        char          *containername,
+        char          *blobname,
+        char          *data,
+        size_t         dataoffset,
+        size_t         datasize,
+        int            nthreads,
+        int            nretry,
+        int            verbose,
+        long           connect_timeout,
+        long           read_timeout)
 {
     size_t thread_datasize = datasize/nthreads;
     size_t thread_dataremainder = datasize%nthreads;
@@ -871,7 +951,15 @@ curl_readbytes_retry_threaded(
         thread_firstbyte += thread_dataremainder;
     }
 
-    struct ResponseCodes responsecodes = curl_readbytes_retry(token, storageaccount, containername, blobname, data+thread_firstbyte, dataoffset+thread_firstbyte, _thread_datasize, nretry, verbose, connect_timeout, read_timeout);
+    char token_local[BUFFER_SIZE];
+    char refresh_token_local[BUFFER_SIZE];
+    unsigned long expiry_local;
+
+    strcpy(token_local, token);
+    strcpy(refresh_token_local, refresh_token);
+    expiry_local = *expiry;
+
+    struct ResponseCodes responsecodes = curl_readbytes_retry(token_local, refresh_token_local, &expiry_local, scope, resource, tenant, clientid, client_secret, storageaccount, containername, blobname, data+thread_firstbyte, dataoffset+thread_firstbyte, _thread_datasize, nretry, verbose, connect_timeout, read_timeout);
     thread_responsecode_http[threadid] = responsecodes.http;
     thread_responsecode_curl[threadid] = responsecodes.curl;
 } /* end pragma omp */

--- a/src/AzStorage.h
+++ b/src/AzStorage.h
@@ -70,34 +70,48 @@ curl_authorization(
 
 struct ResponseCodes
 curl_writebytes_block_retry_threaded(
-    char  *token,
-    char  *storageaccount,
-    char  *containername,
-    char  *blobname,
-    char **blockids,
-    char  *data,
-    size_t datasize,
-    int    nthreads,
-    int    nblocks,
-    int    nretry,
-    int    verbose,
-    long   connect_timeout,
-    long   read_timeout);
+    char           *token,
+    char           *refresh_token,
+    unsigned long  *expiry,
+    char           *scope,
+    char           *tenant,
+    char           *resource,
+    char           *clientid,
+    char           *client_secret,
+    char           *storageaccount,
+    char           *containername,
+    char           *blobname,
+    char          **blockids,
+    char           *data,
+    size_t          datasize,
+    int             nthreads,
+    int             nblocks,
+    int             nretry,
+    int             verbose,
+    long            connect_timeout,
+    long            read_timeout);
 
 struct ResponseCodes
 curl_readbytes_retry_threaded(
-    char  *token,
-    char  *storageaccount,
-    char  *containername,
-    char  *blobname,
-    char  *data,
-    size_t dataoffset,
-    size_t datasize,
-    int    nthreads,
-    int    nretry,
-    int    verbose,
-    long   connect_timeout,
-    long   read_timeout);
+    char          *token,
+    char          *refresh_token,
+    unsigned long *expiry,
+    char          *scope,
+    char          *tenant,
+    char          *resource,
+    char          *clientid,
+    char          *client_secret,
+    char          *storageaccount,
+    char          *containername,
+    char          *blobname,
+    char          *data,
+    size_t         dataoffset,
+    size_t         datasize,
+    int            nthreads,
+    int            nretry,
+    int            verbose,
+    long           connect_timeout,
+    long           read_timeout);
 
 struct ResponseCodes
 curl_refresh_tokens_retry(

--- a/src/AzStorage.jl
+++ b/src/AzStorage.jl
@@ -207,6 +207,39 @@ macro retry(retries, ex::Expr)
     end
 end
 
+function authinfo(session::AzSessions.AzClientCredentialsSession)
+    refresh_token = C_NULL
+    expiry = [floor(UInt64, datetime2unix(session.expiry))]
+    scope = C_NULL
+    resource = session.resource
+    tenant = session.tenant
+    clientid = session.client_id
+    client_secret = session.client_secret
+    refresh_token,expiry,scope,resource,tenant,clientid,client_secret
+end
+
+function authinfo(session::Union{AzSessions.AzDeviceCodeFlowSession,AzSessions.AzAuthCodeFlowSession})
+    refresh_token = session.refresh_token
+    expiry = [floor(UInt64, datetime2unix(session.expiry))]
+    scope = session.scope
+    resource = AzSessions.audience_from_scope(session.scope)
+    tenant = session.tenant
+    clientid = session.client_id
+    client_secret = C_NULL
+    refresh_token,expiry,scope,resource,tenant,clientid,client_secret
+end
+
+function authinfo(session::AzSessions.AzVMSession)
+    refresh_token = C_NULL
+    expiry = [floor(UInt64, datetime2unix(session.expiry))]
+    scope = C_NULL
+    resource = session.resource
+    tenant = C_NULL
+    clientid = C_NULL
+    client_secret = C_NULL
+    refresh_token,expiry,scope,resource,tenant,clientid,client_secret
+end
+
 """
     mkpath(container)
 
@@ -249,64 +282,66 @@ _normpath(s) = Sys.iswindows() ? replace(normpath(s), "\\"=>"/") : normpath(s)
 
 addprefix(c::AzContainer, o) = c.prefix == "" ? o : _normpath("$(c.prefix)/$o")
 
+function writebytes_blob(c, o, data, contenttype)
+    @retry c.nretry HTTP.request(
+        "PUT",
+        "https://$(c.storageaccount).blob.core.windows.net/$(c.containername)/$(addprefix(c,o))",
+        [
+            "Authorization" => "Bearer $(token(c.session))",
+            "x-ms-version" => API_VERSION,
+            "Content-Length" => "$(length(data))",
+            "Content-Type" => contenttype,
+            "x-ms-blob-type" => "BlockBlob"
+        ],
+        data,
+        retry = false,
+        verbose = c.verbose,
+        connect_timeout = c.connect_timeout,
+        readtimeout = c.read_timeout)
+    nothing
+end
+
+function putblocklist(c, o, blockids)
+    xdoc = XMLDocument()
+    xroot = create_root(xdoc, "BlockList")
+    for blockid in blockids
+        add_text(new_child(xroot, "Uncommitted"), blockid)
+    end
+    blocklist = string(xdoc)
+
+    @retry c.nretry HTTP.request(
+        "PUT",
+        "https://$(c.storageaccount).blob.core.windows.net/$(c.containername)/$(addprefix(c,o))?comp=blocklist",
+        [
+            "x-ms-version" => API_VERSION,
+            "Authorization" => "Bearer $(token(c.session))",
+            "Content-Type" => "application/octet-stream",
+            "Content-Length" => "$(length(blocklist))"
+        ],
+        blocklist,
+        retry = false,
+        verbose = c.verbose,
+        connect_timeout = c.connect_timeout,
+        readtimeout = c.read_timeout)
+    nothing
+end
+
+function writebytes_block(c, o, data, _nblocks)
+    # heuristic to increase probability that token is valid during the retry logic in AzSessions.c
+    l = ceil(Int, log10(_nblocks))
+    blockids = [base64encode(lpad(blockid-1, l, '0')) for blockid in 1:_nblocks]
+    _blockids = [HTTP.escapeuri(blockid) for blockid in blockids]
+    t = token(c.session; offset=Minute(10))
+    refresh_token,expiry,scope,resource,tenant,clientid,client_secret = authinfo(c.session)
+    r = @ccall libAzStorage.curl_writebytes_block_retry_threaded(t::Cstring, refresh_token::Cstring, expiry::Ptr{Culong}, scope::Cstring, resource::Cstring, tenant::Cstring,
+        clientid::Cstring, client_secret::Cstring,c.storageaccount::Cstring, c.containername::Cstring, addprefix(c,o)::Cstring, _blockids::Ptr{Cstring}, data::Ptr{UInt8},
+        length(data)::Csize_t, c.nthreads::Cint, _nblocks::Cint, c.nretry::Cint, c.verbose::Cint, c.connect_timeout::Clong, c.read_timeout::Clong)::ResponseCodes
+    (r.http >= 300 || r.curl > 0) && error("writebytes_block error: http code $(r.http), curl code $(r.curl)")
+
+    putblocklist(c, o, blockids)
+end
+
 function writebytes(c::AzContainer, o::AbstractString, data::DenseArray{UInt8}; contenttype="application/octet-stream")
-    function writebytes_blob(c, o, data, contenttype)
-        @retry c.nretry HTTP.request(
-            "PUT",
-            "https://$(c.storageaccount).blob.core.windows.net/$(c.containername)/$(addprefix(c,o))",
-            [
-                "Authorization" => "Bearer $(token(c.session))",
-                "x-ms-version" => API_VERSION,
-                "Content-Length" => "$(length(data))",
-                "Content-Type" => contenttype,
-                "x-ms-blob-type" => "BlockBlob"
-            ],
-            data,
-            retry = false,
-            verbose = c.verbose,
-            connect_timeout = c.connect_timeout,
-            readtimeout = c.read_timeout)
-        nothing
-    end
-
-    function putblocklist(c, o, blockids)
-        xdoc = XMLDocument()
-        xroot = create_root(xdoc, "BlockList")
-        for blockid in blockids
-            add_text(new_child(xroot, "Uncommitted"), blockid)
-        end
-        blocklist = string(xdoc)
-
-        @retry c.nretry HTTP.request(
-            "PUT",
-            "https://$(c.storageaccount).blob.core.windows.net/$(c.containername)/$(addprefix(c,o))?comp=blocklist",
-            [
-                "x-ms-version" => API_VERSION,
-                "Authorization" => "Bearer $(token(c.session))",
-                "Content-Type" => "application/octet-stream",
-                "Content-Length" => "$(length(blocklist))"
-            ],
-            blocklist,
-            retry = false,
-            verbose = c.verbose,
-            connect_timeout = c.connect_timeout,
-            readtimeout = c.read_timeout)
-        nothing
-    end
-
-    function writebytes_block(c, o, data, _nblocks)
-        # heuristic to increase probability that token is valid during the retry logic in AzSessions.c
-        t = token(c.session; offset=Minute(30))
-        l = ceil(Int, log10(_nblocks))
-        blockids = [base64encode(lpad(blockid-1, l, '0')) for blockid in 1:_nblocks]
-        _blockids = [HTTP.escapeuri(blockid) for blockid in blockids]
-        r = @ccall libAzStorage.curl_writebytes_block_retry_threaded(t::Cstring, c.storageaccount::Cstring, c.containername::Cstring, addprefix(c,o)::Cstring, _blockids::Ptr{Cstring},
-            data::Ptr{UInt8}, length(data)::Csize_t, c.nthreads::Cint, _nblocks::Cint, c.nretry::Cint, c.verbose::Cint, c.connect_timeout::Clong, c.read_timeout::Clong)::ResponseCodes
-        (r.http >= 300 || r.curl > 0) && error("writebytes_block error: http code $(r.http), curl code $(r.curl)")
-
-        putblocklist(c, o, blockids)
-    end
-
     _nblocks = nblocks(c.nthreads, length(data))
     if Sys.iswindows()
         writebytes_blob(c, o, data, contenttype)
@@ -487,10 +522,11 @@ function readbytes!(c::AzContainer, o::AbstractString, data::DenseArray{UInt8}; 
 
     function readbytes_threaded!(c, o, data, offset, _nthreads)
         # heuristic to increase probability that token is valid during the retry logic in AzSessions.c
-        t = token(c.session; offset=Minute(30))
-        r = @ccall libAzStorage.curl_readbytes_retry_threaded(t::Cstring, c.storageaccount::Cstring, c.containername::Cstring,
-                addprefix(c,o)::Cstring, data::Ptr{UInt8}, offset::Csize_t, length(data)::Csize_t, _nthreads::Cint, c.nretry::Cint,
-                c.verbose::Cint, c.connect_timeout::Clong, c.read_timeout::Clong)::ResponseCodes
+        t = token(c.session; offset=Minute(10))
+        refresh_token,expiry,scope,resource,tenant,clientid,client_secret = authinfo(c.session)
+        r = @ccall libAzStorage.curl_readbytes_retry_threaded(t::Cstring, refresh_token::Cstring, expiry::Ptr{Culong}, scope::Cstring, resource::Cstring, tenant::Cstring,
+            clientid::Cstring, client_secret::Cstring, c.storageaccount::Cstring, c.containername::Cstring, addprefix(c,o)::Cstring, data::Ptr{UInt8}, offset::Csize_t,
+            length(data)::Csize_t, _nthreads::Cint, c.nretry::Cint, c.verbose::Cint, c.connect_timeout::Clong, c.read_timeout::Clong)::ResponseCodes
         (r.http >= 300 || r.curl > 0) && error("readbytes_threaded! error: http code $(r.http), curl code $(r.curl)")
         nothing
     end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,7 +1,10 @@
 [deps]
 AbstractStorage = "14dbef02-f468-5f15-853e-5ec8dee7b899"
 AzSessions = "f239b30d-ae6b-58be-a2d5-7e9f30e280a9"
+AzStorage_jll = "00c928b4-b5f3-54d8-b38d-afd4635c4ad2"
+Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
Previously, we gave ourselves a 30 minute grace period on tokens before entering the retry loop in C.  This change reduces the grace period to 10 minutes, but adds a call to refresh the token in the retry loop on each thread.  ~Note that this means that there might be a race (amongst the threads) to refresh the token, but I suppose that should be fine.~ We allow each thread to update its own token.  This means some potential redundancy when making calls to the Auth end-point, but the Auth service should be able to handle that.

Note that tests pass locally, but tests will fail in CI until a new version AzStorage_jll is released.

**edit:** I think I prefer #55 